### PR TITLE
Added requirements.txt for Colorama

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Install Colorama Package
+
+colorama


### PR DESCRIPTION
Added requirements.txt in order for users install through 'pip install -r requirements.txt' command before using a program, as error will occur when they run but didn't install the Colorama package in the first place.

```powershell
PS C:\Users\<redacted>\Downloads\character-roll-main> python .\main.py
Traceback (most recent call last):
  File "C:\Users\<redacted>\Downloads\character-roll-main\main.py", line 3, in <module>
    from colorama import init, Fore, Style
ModuleNotFoundError: No module named 'colorama'
```